### PR TITLE
Fix for getIpDetails (returns bool not empty)

### DIFF
--- a/Helper/TimingHelper.php
+++ b/Helper/TimingHelper.php
@@ -187,7 +187,7 @@ class TimingHelper
         
         //attempt to use the contact's timezone (if directed)
         if($timing->getUseContactTimezone()) {
-            if ($lead->getIpAddresses()) {
+            if ($lead->getIpAddresses()->first()) {
                 /** @var $ipDetails array */
                 $ipDetails = $lead->getIpAddresses()->first()->getIpDetails();
                 if( ! empty($ipDetails['timezone'])) {


### PR DESCRIPTION
Fix for PHP Fatal error:  Call to a member function getIpDetails() on boolean in /var/www/html/plugins/ThirdSetMauticTimingBundle/Helper/TimingHelper.php on line 192 (returns boolean and not empty)